### PR TITLE
Change xPlayer loop

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -50,10 +50,10 @@ RegisterNetEvent('Boost-Locksystem:CreateKeyCopy', function(_plate)
 end)
 
 RegisterNetEvent('Boost-Locksystem:Refresh', function()
-    local xPlayers = ESX.GetPlayers()
+    local xPlayers = ESX.GetExtendedPlayers()
     local found = 0
     for i=1, #xPlayers, 1 do
-        local xPlayer = ESX.GetPlayerFromId(xPlayers[i])
+        local xPlayer = xPlayers[i]
         local inventory = xPlayer.getInventory()
         for i=1, tablelength(inventory) do
             if inventory[i].name == 'car_keys' then


### PR DESCRIPTION
Never use ESX.GetPlayers() for an xPlayer loop when using ESX Legacy, it can lead to massive server hitching.
Same issue with the inventory getter - spamming a lot of function references, exports, or events just overloads the scheduler.

In fact you should get rid of this event entirely, but I'm not going to resolve the issue myself.